### PR TITLE
fix: The total column of a project report wasn't adding active frames…

### DIFF
--- a/go-tom/dateTime/DurationSum.go
+++ b/go-tom/dateTime/DurationSum.go
@@ -8,6 +8,12 @@ func NewDurationSum() *DurationSum {
 	return &DurationSum{}
 }
 
+func NewDurationSumWithRef(referenceTime *time.Time) *DurationSum {
+	return &DurationSum{
+		referenceTime: referenceTime,
+	}
+}
+
 func NewEmptyCopy(proto *DurationSum) *DurationSum {
 	return NewDurationSumAll(proto.rounding, proto.acceptedRange, proto.referenceTime)
 }
@@ -63,7 +69,11 @@ func (d *DurationSum) AddStartEnd(start time.Time, end time.Time) {
 }
 
 func (d *DurationSum) AddStartEndP(start *time.Time, end *time.Time) {
-	d.add(start, end)
+	if end == nil {
+		d.add(start, d.referenceTime)
+	} else {
+		d.add(start, end)
+	}
 }
 
 func (d *DurationSum) Add(duration time.Duration) {

--- a/go-tom/report/project_report.go
+++ b/go-tom/report/project_report.go
@@ -11,8 +11,8 @@ import (
 func NewProjectSummary(year *dateTime.DateRange, month *dateTime.DateRange, week *dateTime.DateRange, yesterday *dateTime.DateRange, day *dateTime.DateRange, refTime *time.Time, project *model.Project) *ProjectSummary {
 	summary := &ProjectSummary{
 		Project:               project,
-		TrackedAll:            dateTime.NewDurationSum(),
-		TrackedTotalAll:       dateTime.NewDurationSum(),
+		TrackedAll:            dateTime.NewDurationSumWithRef(refTime),
+		TrackedTotalAll:       dateTime.NewDurationSumWithRef(refTime),
 		TrackedYear:           dateTime.NewDurationSumFiltered(year, refTime),
 		TrackedTotalYear:      dateTime.NewDurationSumFiltered(year, refTime),
 		TrackedMonth:          dateTime.NewDurationSumFiltered(month, refTime),


### PR DESCRIPTION
… when a reference timestamp was specified